### PR TITLE
pip install gsutil fails due to cffi-1.6.0 requiring compile deps.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,22 @@ FROM alpine
 
 MAINTAINER Camil Blanaru <camil@edka.io>
 
+#install deps and install gsutil
 RUN apk add --update \
     python \
     py-pip \
     py-cffi \
     py-cryptography \
   && pip install --upgrade pip \
+  && apk add --virtual build-deps \
+    gcc \
+    libffi-dev \
+    python-dev \
+    linux-headers \
+    musl-dev \
+    openssl-dev \
+  && pip install gsutil \
+  && apk del build-deps \
   && rm -rf /var/cache/apk/*
-
-#install gsutil
-RUN pip install gsutil
 
 CMD ["gsutil"]


### PR DESCRIPTION
Some new requirements in cffi-1.6.0 seem to be causing the docker build to fail, as it now requires compile deps.

Error encountered, which this PR fixes:

```
...
Collecting cffi>=1.4.1 (from cryptography>=1.3->pyOpenSSL>=0.13->gsutil)
  Downloading cffi-1.6.0.tar.gz (397kB)
    Complete output from command python setup.py egg_info:
    unable to execute 'gcc': No such file or directory
    unable to execute 'gcc': No such file or directory

        No working compiler found, or bogus compiler options
        passed to the compiler from Python's distutils module.
        See the error messages above.
        (If they are about -mno-fused-madd and you are on OS/X 10.8,
        see http://stackoverflow.com/questions/22313407/ .)
```
